### PR TITLE
Fixed activity screen layout for Google Pixel

### DIFF
--- a/PreferencesManager/build.gradle
+++ b/PreferencesManager/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.0"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 24
 
         versionName "1.8.3"
         versionCode 183


### PR DESCRIPTION
Not sure how it is related to Google Pixel devices per se (most likely this is related to newer Android versions, excuse me not being an Android developer), but this seems to be a common issue for older apps I still may use, sometimes found at F-Droid: they may have their activities padded at the bottom.

This seems to be fixed in #19, but I didn't built that PR due to heavy changes it pushes.

Yeah, I know this app wasn't updated for six years, but this app is still cool.

Before:
![before](https://user-images.githubusercontent.com/1956806/235739507-6d7097ff-8b93-4050-be9c-7915203dbdd8.png)

After:
![after](https://user-images.githubusercontent.com/1956806/235739539-626536f1-0cfb-45c4-88a3-a9517916c7f6.png)

